### PR TITLE
Add macos 10.15 back

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
   build-cpp:
     strategy:
       matrix:
-        platform: [ windows-2022, ubuntu-20.04, macos-10.15 ]
+        platform: [ windows-2022, ubuntu-20.04, macos-11 ]
         arch: [ x64 ]
       fail-fast: false
 
@@ -80,16 +80,16 @@ jobs:
           toolset: 14.2
           arch: ${{ matrix.arch }}
       - name: Download Artifacts for macOS
-        if: matrix.platform == 'macos-10.15'
+        if: matrix.platform == 'macos-11'
         uses: actions/download-artifact@v3
         with:
           path: download-artifact
       # ========================================================================================================= Qt Install
-      - name: macOS - Install Qt 6.5
-        if: matrix.platform == 'macos-10.15'
+      - name: macOS - Install Qt 5.15
+        if: matrix.platform == 'macos-11'
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5.0
+          version: 5.15.2
           py7zrversion: ' '
           aqtversion: ' '
           setup-python: false
@@ -157,7 +157,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -DQT_VERSION_MAJOR=6 -DCMAKE_BUILD_TYPE=Release -DNKR_PACKAGE_MACOS=1 ..
+          cmake -GNinja -DQT_VERSION_MAJOR=5 -DCMAKE_BUILD_TYPE=Release -DNKR_PACKAGE_MACOS=1 ..
           ninja
           cd ..
           ./libs/deploy_macos.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
   build-cpp:
     strategy:
       matrix:
-        platform: [ windows-2022, ubuntu-20.04, macos-11 ]
+        platform: [ windows-2022, ubuntu-20.04, macos-10.15 ]
         arch: [ x64 ]
       fail-fast: false
 
@@ -80,13 +80,13 @@ jobs:
           toolset: 14.2
           arch: ${{ matrix.arch }}
       - name: Download Artifacts for macOS
-        if: matrix.platform == 'macos-11'
+        if: matrix.platform == 'macos-10.15'
         uses: actions/download-artifact@v3
         with:
           path: download-artifact
       # ========================================================================================================= Qt Install
       - name: macOS - Install Qt 6.5
-        if: matrix.platform == 'macos-11'
+        if: matrix.platform == 'macos-10.15'
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.0

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -177,6 +177,12 @@ jobs:
     needs:
       - build-cpp
       - build-go
+    permissions:
+      contents: write
+      packages: write
+      actions: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checking out sources
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,8 @@ on:
       artifact-pack:
         description: 'artifact-pack: If want ignore'
         required: false
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.15"  # Add the global environment variable here
 jobs:
   build-go:
     strategy:

--- a/libs/deploy_common.sh
+++ b/libs/deploy_common.sh
@@ -3,3 +3,4 @@ SRC_ROOT="$PWD"
 DEPLOYMENT="$SRC_ROOT/deployment"
 BUILD="$SRC_ROOT/build"
 version_standalone="nekoray-"$(cat nekoray_version.txt)
+MACOSX_DEPLOYMENT_TARGET="10.15"


### PR DESCRIPTION
All I did was to set an environment variable to build for minimum of 10.15 and also change QT version to 5 instead of 6 only for MacOS since https://doc.qt.io/qt-5/macos.html supports 10.15 but https://doc.qt.io/qt-6/macos.html 10.16 doesn't.

Build is successful and I'm currently connected to it as I'm talking to you! Thanks for the help you provided at https://github.com/naverMeet/nekoray/issues/38#issuecomment-1565285054!